### PR TITLE
Add missing PWM indicators to variant file diagrams

### DIFF
--- a/WickedDevice/variants/wildfirev2/pins_arduino.h
+++ b/WickedDevice/variants/wildfirev2/pins_arduino.h
@@ -49,7 +49,7 @@
 //  PCINT27/TXD1/INT1 (D 3) PD3 12|        |33  PA4 (D18/AIN4) PCINT4/ADC4
 // PCINT28/XCK1/OC1B *(D 4) PD4 13|        |32  PA5 (D19/AIN5) PCINT5/ADC5
 //      PCINT29/OC1A *(D 5) PD5 14|        |31  PA6 (D20/AIN6) PCINT6/ADC6
-//   PCINT30/OC2B/ICP (D 6) PD6 15|        |30  PA7 (D21/AIN7) PCINT7/ADC7
+//  PCINT30/OC2B/ICP *(D 6) PD6 15|        |30  PA7 (D21/AIN7) PCINT7/ADC7
 //       PCINT31/OC2A (D 7) PD7 16|        |29  AREF
 //                          VCC 17|        |28  GND
 //                          GND 18|        |27  AVCC

--- a/WickedDevice/variants/wildfirev3/pins_arduino.h
+++ b/WickedDevice/variants/wildfirev3/pins_arduino.h
@@ -49,8 +49,8 @@
 //  PCINT27/TXD1/INT1 (D 3) PD3 12|        |33  PA4 (D28/AIN4) PCINT4/ADC4
 // PCINT28/XCK1/OC1B *(D 8) PD4 13|        |32  PA5 (D29/AIN5) PCINT5/ADC5
 //      PCINT29/OC1A *(D 5) PD5 14|        |31  PA6 (D30/AIN6) PCINT6/ADC6
-//   PCINT30/OC2B/ICP (D 6) PD6 15|        |30  PA7 (D31/AIN7) PCINT7/ADC7
-//       PCINT31/OC2A (D10) PD7 16|        |29  AREF
+//  PCINT30/OC2B/ICP *(D 6) PD6 15|        |30  PA7 (D31/AIN7) PCINT7/ADC7
+//      PCINT31/OC2A *(D10) PD7 16|        |29  AREF
 //                          VCC 17|        |28  GND
 //                          GND 18|        |27  AVCC
 //        PCINT16/SCL (D20) PC0 19|        |26  PC7 (D18) PCINT23/TOSC2


### PR DESCRIPTION
Arduino pin 6 was missing the PWM indicator in both v2 and v3 diagrams.
Pin 10 was missing the indicator in the v3 diagram. I left the indicator
off of v2's pin 7 since it's dedicated to the MAC/EEPROM Chip.
